### PR TITLE
dockerfile: don't remove libltdl-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN go get -u golang.org/x/vgo && \
     cd $GOPATH/src/go.mozilla.org/autograph-edge && \
     make install
 
-RUN apt-get -y remove clang libltdl-dev && \
+RUN apt-get -y remove clang && \
     apt-get clean && \
     apt-get -y autoremove
 


### PR DESCRIPTION
functional tests:

- [x] build and run docker image locally:

```
docker build -t autograph-edge:build .
docker run autograph-edge:build
{"Timestamp":1532629028934534626,"Time":"2018-07-26T18:17:08Z","Type":"app.log","Logger":"autograph-edge","Hostname":"5096a850094d","EnvVersion":"2.0","Pid":8,"Severity":4,"Fields":{"msg":"start server on port 8080"}}
```

r? @milescrabill 