### PR TITLE
main: add optional autograph url param

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,13 +60,21 @@ func init() {
 }
 
 func main() {
-	var cfgFile string
+	var (
+		cfgFile      string
+		autographURL string
+	)
 	flag.StringVar(&cfgFile, "c", "autograph-edge.yaml", "Path to configuration file")
+	flag.StringVar(&autographURL, "u", "", "Upstream Autograph URL")
 	flag.Parse()
 
 	err := conf.loadFromFile(cfgFile)
 	if err != nil {
 		log.Fatal(err)
+	}
+	if autographURL != "" {
+		log.Infof("using commandline autograph URL %s instead of conf %s", autographURL, conf.URL)
+		conf.URL = autographURL
 	}
 
 	http.HandleFunc("/sign", sigHandler)
@@ -74,7 +82,7 @@ func main() {
 	http.HandleFunc("/__heartbeat__", heartbeatHandler)
 	http.HandleFunc("/__lbheartbeat__", versionHandler)
 
-	log.Info("start server on port 8080")
+	log.Infof("start server on port 8080 with upstream autograph %s", conf.URL)
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 


### PR DESCRIPTION
fixes: #10 

This allows me to test autograph and autograph edge against encrypted configs without decrypting them (which comes up when adding a new APK key). Might be useful for CI too.

r? @ajvb or @jvehent 

I think AJ needs to be adding as a collaborator.


Functional Tests:

- [x] Just the example config works:

```
autograph-edge autograph-edge.yaml
{"Timestamp":1535393020167093194,"Time":"2018-08-27T18:03:40Z","Type":"app.log","Logger":"autograph-edge","Hostname":"gguthe-ThinkPad-X1-Carbon-6th","EnvVersion":"2.0","Pid":21642,"Severity":4,"Fields":{"msg":"start server on port 8080 with upstream autograph http://localhost:8000/sign/file"}}
```

- [x] override via arg works:

```
autograph-edge -u https://example.com:9090/flo/blog autograph-edge.yaml
{"Timestamp":1535393053032429851,"Time":"2018-08-27T18:04:13Z","Type":"app.log","Logger":"autograph-edge","Hostname":"gguthe-ThinkPad-X1-Carbon-6th","EnvVersi
on":"2.0","Pid":21784,"Severity":4,"Fields":{"msg":"using commandline autograph URL https://example.com:9090/flo/blog instead of conf http://localhost:8000/si
gn/file"}}     
{"Timestamp":1535393053032628672,"Time":"2018-08-27T18:04:13Z","Type":"app.log","Logger":"autograph-edge","Hostname":"gguthe-ThinkPad-X1-Carbon-6th","EnvVersi
on":"2.0","Pid":21784,"Severity":4,"Fields":{"msg":"start server on port 8080 with upstream autograph https://example.com:9090/flo/blog"}}
```

NB: -u arg must be first:

```
autograph-edge autograph-edge.yaml -u https://example.com:9090/flo/blog
{"Timestamp":1535393043948035627,"Time":"2018-08-27T18:04:03Z","Type":"app.log","Logger":"autograph-edge","Hostname":"gguthe-ThinkPad-X1-Carbon-6th","EnvVersi
on":"2.0","Pid":21720,"Severity":4,"Fields":{"msg":"start server on port 8080 with upstream autograph http://localhost:8000/sign/file"}}
```