### PR TITLE
Reduce image size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ version: 2
 jobs:
   test:
     docker:
-        - image: circleci/golang:1.13-buster
+        - image: circleci/golang:1.14-buster
     environment:
       # docker-compose will default to the project directory which
       # defaults to 'project' on CCI and conflicts with other CCI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 # DOCKER_USER
 # DOCKER_PASS
 #
-version: 2
+version: 2.1
 jobs:
   test:
     docker:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,5 @@
 integration_test/
+.git/
+coverage.out
+docker-compose.yml
+Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,15 +7,13 @@ services:
   edge:
     build:
       context: .
-    environment:
-      - GOPATH=/go
     links:
       - app
     ports:
       - "8080:8080"
     command:
       [
-        "/go/bin/autograph-edge",
+        "/usr/local/bin/autograph-edge",
         "-u",
         "http://app:8000/sign/file",
       ]


### PR DESCRIPTION
fixes: #8 

reduce docker image size 52% from [~600MB](https://hub.docker.com/r/mozilla/autographedge/tags/?page=1&ordering=last_updated) to ~288MB which is smaller than the latest autograph image of [~544MB](https://hub.docker.com/r/mozilla/autograph/tags/?page=1&ordering=last_updated) using multi-stage builds and switching from golang to debian images and the debian slim variant.

Functional tests:

- [x] `docker run -it --rm app:build` run
- [x] `docker run -it --rm app:build /bin/bash -c "ldd /usr/local/bin/autograph-edge"` shows all linked libraries