### PR TITLE
rename token to client_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ability to sign a given apk or xpi.
 
 Client are expected to use curl - or similar - to interact with the webapp. An
 unsigned file is submitted to the `/sign/` endpoint along with an authorization
-token. The HTTP response contains the signed file.
+client_token. The HTTP response contains the signed file.
 
 ```bash
 curl -F "input=@/tmp/unsigned.apk" -o /tmp/signed.apk \
@@ -27,14 +27,14 @@ The yaml file `autograph-edge.yaml` the location of the autograph server in
 
 ```yaml
 authorizations:
-    - token: c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547
+    - client_token: c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547
       addonid: myaddon@allizom.org
       user: alice
       key: fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu
       signer: extensions-ecdsa
 ```
 
-Each authorization has a `token` that clients send in their `Authorization` HTTP
+Each authorization has a `client_token` that clients send in their `Authorization` HTTP
 headers.
 
 The authorization also has a `user`, `key` and `signer` that are used to call
@@ -52,5 +52,5 @@ is the ID of the add-on being signed. It can also include the optional params:
 The sample configuration file in this repository can get you started.
 
 
-Note that the token must be longer than 60 characters. You should use `openssl
+Note that the client_token must be longer than 60 characters. You should use `openssl
 rand -hex 32` to generate it.

--- a/autograph-edge.yaml
+++ b/autograph-edge.yaml
@@ -4,13 +4,13 @@ authorizations:
     # the following token is allowed to sign a web extension with a pre-defined
     # add-on ID. This is enforced by autograph-edge so the caller cannot sign a
     # different add-on.
-    - token: c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547
+    - client_token: c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547
       addonid: myaddon@allizom.org
       user: alice
       key: fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu
       signer: extensions-ecdsa
 
-    - token: b8c8c00f310c9e160dda75790df6be106e29607fde3c1092287d026c014be880
+    - client_token: b8c8c00f310c9e160dda75790df6be106e29607fde3c1092287d026c014be880
       addonid: mycoseaddon@allizom.org
       addonpkcs7digest: SHA256
       addoncosealgorithms:
@@ -22,7 +22,7 @@ authorizations:
     # the following token is allowed to sign an android APK using a specific
     # signer, which maps to a specific private key. since android uses key pinning,
     # this signer cannot sign a different android application
-    - token: dd095f88adbf7bdfa18b06e23e83896107d7e0f969f7415830028fa2c1ccf9fd
+    - client_token: dd095f88adbf7bdfa18b06e23e83896107d7e0f969f7415830028fa2c1ccf9fd
       user: alice
       key: fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu
       signer: testapp-android

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ type configuration struct {
 }
 
 type authorization struct {
-	Token               string
+	ClientToken         string `yaml:"client_token"`
 	Signer              string
 	User                string
 	Key                 string
@@ -197,7 +197,7 @@ func (c *configuration) loadFromFile(path string) error {
 
 func authorize(authHeader string) (auth authorization, err error) {
 	for _, auth := range conf.Authorizations {
-		if authHeader == auth.Token {
+		if authHeader == auth.ClientToken {
 			return auth, nil
 		}
 	}
@@ -299,11 +299,11 @@ func findDuplicateClientToken(auths []authorization) error {
 	seenTokenIndexes := map[string]int{}
 
 	for i, auth := range auths {
-		seenTokenIndex, exists := seenTokenIndexes[auth.Token]
+		seenTokenIndex, exists := seenTokenIndexes[auth.ClientToken]
 		if exists {
 			return fmt.Errorf("found duplicate client token at positions %d and %d", seenTokenIndex, i)
 		}
-		seenTokenIndexes[auth.Token] = i
+		seenTokenIndexes[auth.ClientToken] = i
 	}
 	return nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -227,3 +227,109 @@ func Test_findDuplicateClientToken(t *testing.T) {
 		})
 	}
 }
+
+func Test_validateAuth(t *testing.T) {
+	type args struct {
+		auth authorization
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "valid auth",
+			args: args{
+				auth: authorization{
+					ClientToken: "c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547",
+					Signer:      "extensions-ecdsa",
+					User:        "alice",
+					Key:         "fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid auth with all optional fields",
+			args: args{
+				auth: authorization{
+					ClientToken:         "c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547",
+					Signer:              "extensions-ecdsa",
+					User:                "alice",
+					Key:                 "fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu",
+					AddonID:             "mycoseaddon@allizom.org",
+					AddonPKCS7Digest:    "SHA256",
+					AddonCOSEAlgorithms: []string{"ES256"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid auth empty client token",
+			args: args{
+				auth: authorization{
+					ClientToken:         "",
+					Signer:              "extensions-ecdsa",
+					User:                "alice",
+					Key:                 "fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid auth short client token",
+			args: args{
+				auth: authorization{
+					ClientToken:         "1234",
+					Signer:              "extensions-ecdsa",
+					User:                "alice",
+					Key:                 "fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid auth empty autograph signer id",
+			args: args{
+				auth: authorization{
+					ClientToken:         "c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547",
+					Signer:              "",
+					User:                "alice",
+					Key:                 "fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid auth empty autograph user id",
+			args: args{
+				auth: authorization{
+					ClientToken:         "c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547",
+					Signer:              "extensions-ecdsa",
+					User:                "",
+					Key:                 "fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid auth empty autograph user key",
+			args: args{
+				auth: authorization{
+					ClientToken:         "c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547",
+					Signer:              "extensions-ecdsa",
+					User:                "alice",
+					Key:                 "",
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateAuth(tt.args.auth); (err != nil) != tt.wantErr {
+				t.Errorf("validateAuth() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -168,13 +168,13 @@ func Test_findDuplicateClientToken(t *testing.T) {
 			args: args{
 				auths: []authorization{
 					authorization{
-						Token: "c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547",
+						ClientToken: "c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547",
 					},
 					authorization{
-						Token: "b8c8c00f310c9e160dda75790df6be106e29607fde3c1092287d026c014be880",
+						ClientToken: "b8c8c00f310c9e160dda75790df6be106e29607fde3c1092287d026c014be880",
 					},
 					authorization{
-						Token: "dd095f88adbf7bdfa18b06e23e83896107d7e0f969f7415830028fa2c1ccf9fd",
+						ClientToken: "dd095f88adbf7bdfa18b06e23e83896107d7e0f969f7415830028fa2c1ccf9fd",
 					},
 				},
 			},
@@ -185,12 +185,12 @@ func Test_findDuplicateClientToken(t *testing.T) {
 			args: args{
 				auths: []authorization{
 					authorization{
-						Token:  "c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547",
-						Signer: "spam",
+						ClientToken: "c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547",
+						Signer:      "spam",
 					},
 					authorization{
-						Token:  "c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547",
-						Signer: "eggs",
+						ClientToken: "c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547",
+						Signer:      "eggs",
 					},
 				},
 			},
@@ -201,18 +201,18 @@ func Test_findDuplicateClientToken(t *testing.T) {
 			args: args{
 				auths: []authorization{
 					authorization{
-						Token:  "c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547",
-						Signer: "spam",
+						ClientToken: "c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547",
+						Signer:      "spam",
 					},
 					authorization{
-						Token: "b8c8c00f310c9e160dda75790df6be106e29607fde3c1092287d026c014be880",
+						ClientToken: "b8c8c00f310c9e160dda75790df6be106e29607fde3c1092287d026c014be880",
 					},
 					authorization{
-						Token: "dd095f88adbf7bdfa18b06e23e83896107d7e0f969f7415830028fa2c1ccf9fd",
+						ClientToken: "dd095f88adbf7bdfa18b06e23e83896107d7e0f969f7415830028fa2c1ccf9fd",
 					},
 					authorization{
-						Token:  "c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547",
-						Signer: "eggs",
+						ClientToken: "c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547",
+						Signer:      "eggs",
 					},
 				},
 			},


### PR DESCRIPTION
Fixes: #12 

Changes:

* **breaking** rename `token` to `client_token` in auth config
* validate auth client token length; validate other required auth fields are not empty