### PR TITLE
Refactor tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/
+coverage.out

--- a/main_test.go
+++ b/main_test.go
@@ -307,10 +307,10 @@ func Test_validateAuth(t *testing.T) {
 			name: "invalid auth empty client token",
 			args: args{
 				auth: authorization{
-					ClientToken:         "",
-					Signer:              "extensions-ecdsa",
-					User:                "alice",
-					Key:                 "fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu",
+					ClientToken: "",
+					Signer:      "extensions-ecdsa",
+					User:        "alice",
+					Key:         "fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu",
 				},
 			},
 			wantErr: true,
@@ -319,10 +319,10 @@ func Test_validateAuth(t *testing.T) {
 			name: "invalid auth short client token",
 			args: args{
 				auth: authorization{
-					ClientToken:         "1234",
-					Signer:              "extensions-ecdsa",
-					User:                "alice",
-					Key:                 "fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu",
+					ClientToken: "1234",
+					Signer:      "extensions-ecdsa",
+					User:        "alice",
+					Key:         "fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu",
 				},
 			},
 			wantErr: true,
@@ -331,10 +331,10 @@ func Test_validateAuth(t *testing.T) {
 			name: "invalid auth empty autograph signer id",
 			args: args{
 				auth: authorization{
-					ClientToken:         "c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547",
-					Signer:              "",
-					User:                "alice",
-					Key:                 "fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu",
+					ClientToken: "c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547",
+					Signer:      "",
+					User:        "alice",
+					Key:         "fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu",
 				},
 			},
 			wantErr: true,
@@ -343,10 +343,10 @@ func Test_validateAuth(t *testing.T) {
 			name: "invalid auth empty autograph user id",
 			args: args{
 				auth: authorization{
-					ClientToken:         "c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547",
-					Signer:              "extensions-ecdsa",
-					User:                "",
-					Key:                 "fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu",
+					ClientToken: "c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547",
+					Signer:      "extensions-ecdsa",
+					User:        "",
+					Key:         "fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu",
 				},
 			},
 			wantErr: true,
@@ -355,10 +355,10 @@ func Test_validateAuth(t *testing.T) {
 			name: "invalid auth empty autograph user key",
 			args: args{
 				auth: authorization{
-					ClientToken:         "c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547",
-					Signer:              "extensions-ecdsa",
-					User:                "alice",
-					Key:                 "",
+					ClientToken: "c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547",
+					Signer:      "extensions-ecdsa",
+					User:        "alice",
+					Key:         "",
 				},
 			},
 			wantErr: true,

--- a/main_test.go
+++ b/main_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestMain(m *testing.M) {
 	// load the signers
-	err := conf.loadFromFile(os.Getenv("GOPATH") + "/src/go.mozilla.org/autograph-edge/autograph-edge.yaml")
+	err := conf.loadFromFile("./autograph-edge.yaml")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -126,7 +126,7 @@ func TestHeartbeatRequestFailure(t *testing.T) {
 	req := httptest.NewRequest("GET", "http://localhost:8080/__heartbeat__", nil)
 	w := httptest.NewRecorder()
 
-	heartbeatBadURLBody := []byte("{\"status\":false,\"checks\":{\"check_autograph_heartbeat\":false},\"details\":\"failed to request autograph heartbeat from :///__heartbeat__: parse :///__heartbeat__: missing protocol scheme\"}")
+	heartbeatBadURLBody := []byte("{\"status\":false,\"checks\":{\"check_autograph_heartbeat\":false},\"details\":\"failed to request autograph heartbeat from :///__heartbeat__: parse \\\":///__heartbeat__\\\": missing protocol scheme\"}")
 
 	heartbeatHandler(w, req)
 


### PR DESCRIPTION
Changes:
* make authorize and heartbeat tests table-based
* load the local `autograph-edge.yaml` config (with modules the latest version isn't necessarily at `$GOPATH/src/go.mozilla.org/autograph-edge/`)
