### PR TITLE
rename config url to autograph_base_url

### DIFF
--- a/autograph-edge.yaml
+++ b/autograph-edge.yaml
@@ -1,4 +1,4 @@
-url: http://localhost:8000/sign/file
+autograph_base_url: http://localhost:8000/
 
 authorizations:
     # the following token is allowed to sign a web extension with a pre-defined

--- a/client.go
+++ b/client.go
@@ -55,7 +55,7 @@ func callAutograph(auth authorization, body []byte, xff string) (signedBody []by
 		return
 	}
 	rdr := bytes.NewReader(reqBody)
-	req, err := http.NewRequest(http.MethodPost, conf.URL, rdr)
+	req, err := http.NewRequest(http.MethodPost, conf.BaseURL+"sign/file", rdr)
 	if err != nil {
 		return
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       [
         "/usr/local/bin/autograph-edge",
         "-u",
-        "http://app:8000/sign/file",
+        "http://app:8000/",
       ]
   test:
     build:

--- a/main_test.go
+++ b/main_test.go
@@ -113,7 +113,7 @@ func Test_heartbeatHandler(t *testing.T) {
 			args: args{
 				r: httptest.NewRequest("GET", "http://localhost:8080/__heartbeat__", nil),
 			},
-			autographURL: conf.URL,
+			autographURL: conf.BaseURL,
 			expectedResponse: expectedResponse{
 				status:      http.StatusOK,
 				contentType: "application/json",
@@ -147,9 +147,9 @@ func Test_heartbeatHandler(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			origURL := conf.URL
+			origURL := conf.BaseURL
 
-			conf.URL = tt.autographURL
+			conf.BaseURL = tt.autographURL
 			w := httptest.NewRecorder()
 
 			heartbeatHandler(w, tt.args.r)
@@ -157,7 +157,7 @@ func Test_heartbeatHandler(t *testing.T) {
 			resp := w.Result()
 			body, _ := ioutil.ReadAll(resp.Body)
 
-			conf.URL = origURL
+			conf.BaseURL = origURL
 
 			if resp.StatusCode != tt.expectedResponse.status {
 				t.Fatalf("heartbeatHandler() returned unexpected status %v expected %v", resp.StatusCode, tt.expectedResponse.status)


### PR DESCRIPTION
Changes:

* **breaking** change for v2 rename config `url` to `autograph_base_url` and `conf.URL` to `conf.BaseURL`
