### PR TITLE
Revert "Bump golang from 1.17.3-buster to 1.17.6-buster"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.6-buster AS build
+FROM golang:1.17.3-buster AS build
 ENV GO111MODULE on
 
 RUN apt update && \


### PR DESCRIPTION
Reverts mozilla-services/autograph-edge#271 -- hwine forgot that we are in maintenance mode.