### PR TITLE
Support debian stretch past EOL for test harness

### DIFF
--- a/integration_test/Dockerfile
+++ b/integration_test/Dockerfile
@@ -1,5 +1,16 @@
 FROM circleci/android:api-25-node8-alpha
 
+# from https://stackoverflow.com/a/49585503 fixes "NO_PUBKEY
+# B53DC80D13EDEF05" issue
+RUN curl -s  -f https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add - 2>/dev/null
+
+# debian stretch is out of support, so update URLs
+# from https://stackoverflow.com/a/76095392
+# Update stretch repositories
+RUN sudo sed -i -e 's/deb.debian.org/archive.debian.org/g' \
+           -e 's|security.debian.org|archive.debian.org/|g' \
+           -e '/stretch-updates/d' /etc/apt/sources.list
+
 RUN sudo apt-get update && \
     sudo apt-get install -y curl netcat android-sdk-build-tools
 


### PR DESCRIPTION
Migrating to newer release is a project for the future.

Fixes #305