### PR TITLE
AUT-124: update to debian bookworm & golang 1.22.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,25 +8,25 @@ version: 2.1
 jobs:
   unit-test:
     docker:
-        - image: circleci/golang:1.16-buster
+        - image: cimg/go:1.22
     steps:
       - checkout
 
       - run:
           name: Run unit tests
           command: |
-              sudo apt -y install libltdl-dev
+              sudo apt update && sudo apt -y install libltdl-dev
               PATH=/usr/local/go/bin:$PATH make test
 
       - run:
           name: Report unit test coverage
           command: |
-              go get github.com/mattn/goveralls
+              go install github.com/mattn/goveralls@latest
               goveralls -coverprofile=coverage.out -service=circle-ci -repotoken $COVERALLS_REPO_TOKEN
 
   test:
     docker:
-        - image: circleci/golang:1.16-buster
+        - image: cimg/go:1.22
     environment:
       # docker-compose will default to the project directory which
       # defaults to 'project' on CCI and conflicts with other CCI
@@ -34,8 +34,7 @@ jobs:
       COMPOSE_PROJECT_NAME: autograph_edge
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 18.09.3
+      - setup_remote_docker
 
       - run:
           name: Install Autograph
@@ -69,8 +68,7 @@ jobs:
               apk add git openssh
 
       - checkout
-      - setup_remote_docker:
-          version: 18.09.3
+      - setup_remote_docker
 
       - run:
           name: Create a version.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,58 @@
-FROM golang:1.17.3-buster AS build
-ENV GO111MODULE on
+ARG GO_VERSION=1.22
 
-RUN apt update && \
-    apt -y upgrade && \
-    apt -y install clang libltdl-dev && \
-    apt-get clean
+#------------------------------------------------------------------------------
+# Base Debian Image
+#------------------------------------------------------------------------------
+FROM debian:bookworm as base
+ARG GO_VERSION
 
-ADD . $GOPATH/src/github.com/mozilla-services/autograph-edge
+ENV DEBIAN_FRONTEND='noninteractive' \
+    PATH="${PATH}:/usr/lib/go-${GO_VERSION}/bin:/go/bin" \
+    GOPATH='/go'
 
-RUN cd $GOPATH/src/github.com/mozilla-services/autograph-edge && \
-    make install
+## Enable bookworm-backports
+RUN echo "deb http://deb.debian.org/debian/ bookworm-backports main" > /etc/apt/sources.list.d/bookworm-backports.list
+RUN echo "deb-src http://deb.debian.org/debian/ bookworm-backports main" >> /etc/apt/sources.list.d/bookworm-backports.list
 
-RUN apt-get -y remove clang && \
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get -y install --no-install-recommends \
+        clang \
+        gcc \
+        libltdl-dev \
+        golang-${GO_VERSION} \
+        curl \
+        ca-certificates && \
+    # Cleanup inline with installation to avoid this layer being bloated with
+    # deb packages and other cached data.
     apt-get clean && \
-    apt-get -y autoremove
+    rm -rf /var/lib/apt/lists/*
 
-FROM debian:buster-slim
+#------------------------------------------------------------------------------
+# Build Stage
+#------------------------------------------------------------------------------
+FROM base as builder
+ENV GO111MODULE on
+ENV CGO_ENABLED 1
+
+ADD . /app/src/autograph
+
+RUN cd /app/src/autograph && go install .
+
+#------------------------------------------------------------------------------
+# Deployment Stage
+#------------------------------------------------------------------------------
+FROM base
 EXPOSE 8080
 
-RUN apt update && \
-    apt -y upgrade && \
-    apt -y install libltdl-dev ca-certificates && \
-    apt-get clean
-
-COPY --from=build /go/bin/autograph-edge /usr/local/bin
-
-RUN addgroup --gid 10001 app && \
-    adduser --gid 10001 --uid 10001 \
-    --home /app --shell /sbin/nologin \
-    --disabled-password app
-
+# Copy compiled appliation from the builder.
+ADD . /app/src/autograph
 ADD autograph-edge.yaml /app
 ADD version.json /app
+COPY --from=builder /go/bin/autograph-edge /usr/local/bin/autograph-edge
 
+# Setup the worker and entrypoint.
+RUN useradd --uid 10001 --home-dir /app --shell /sbin/nologin app
 USER app
 WORKDIR /app
 CMD /usr/local/bin/autograph-edge

--- a/go.mod
+++ b/go.mod
@@ -1,30 +1,50 @@
 module github.com/mozilla-services/autograph-edge
 
 require (
+	github.com/golang/mock v1.6.0
+	github.com/pkg/errors v0.9.1
+	github.com/sirupsen/logrus v1.8.1
+	go.mozilla.org/autograph v0.0.0-20181011130409-bbb33dd2ff13
+	go.mozilla.org/hawk v0.0.0-20160602144717-b9704677ebef
+	go.mozilla.org/mozlogrus v2.0.0+incompatible
+	go.mozilla.org/sops v0.0.0-20180531162322-5e8d1390eb4c
+	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
 	cloud.google.com/go v0.78.0 // indirect
 	github.com/ThalesIgnite/crypto11 v0.0.0-20180625122339-a49ec8bedc9a // indirect
 	github.com/aws/aws-sdk-go v1.37.25 // indirect
 	github.com/fatih/color v1.10.0 // indirect
-	github.com/golang/mock v1.6.0
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
 	github.com/goware/prefixer v0.0.0-20160118172347-395022866408 // indirect
 	github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/lib/pq v0.0.0-20180523175426-90697d60dd84 // indirect
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/miekg/pkcs11 v0.0.0-20180425180052-287d9350987c // indirect
 	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
 	github.com/mozilla-services/yaml v0.0.0-20201007153854-c369669a6625 // indirect
-	github.com/pkg/errors v0.9.1
-	github.com/sirupsen/logrus v1.8.1
 	github.com/ugorji/go v1.1.1 // indirect
 	github.com/youtube/vitess v2.1.1+incompatible // indirect
-	go.mozilla.org/autograph v0.0.0-20181011130409-bbb33dd2ff13
 	go.mozilla.org/cose v0.0.0-20180718182446-1eaf5a0651d7 // indirect
 	go.mozilla.org/gopgagent v0.0.0-20170926210634-4d7ea76ff71a // indirect
-	go.mozilla.org/hawk v0.0.0-20160602144717-b9704677ebef
-	go.mozilla.org/mozlogrus v2.0.0+incompatible
 	go.mozilla.org/pkcs7 v0.0.0-20180321134453-930bd84804d7 // indirect
-	go.mozilla.org/sops v0.0.0-20180531162322-5e8d1390eb4c
+	go.opencensus.io v0.22.5 // indirect
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99 // indirect
+	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
+	golang.org/x/text v0.3.5 // indirect
+	google.golang.org/api v0.40.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20210222152913-aa3ee6e6a81c // indirect
 	google.golang.org/grpc v1.36.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0
+	google.golang.org/protobuf v1.25.0 // indirect
 )
 
-go 1.16
+go 1.22.5


### PR DESCRIPTION
I've done my best to pull in the enhancements and style changes made to autograph in https://github.com/mozilla-services/autograph/pull/898 over here as well.

Unlike that repo, this required no changes to bring up to the latest stable go version - so I've done that as part of this (we had to upgrade to _some_ new version, so there was no reason to pull in the latest).

It also necessitated changing images and docker versions in the CircleCI jobs, which required some small tweaks to their payloads. There might be other changes we want to make there, but I'm trying to keep this as minimal as possible for now.