### PR TITLE
Add healthchecks for autograph & autograph-edge in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,18 @@ services:
     image: mozilla/autograph
     ports:
       - "8000:8000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/__heartbeat__"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+
   edge:
     build:
       context: .
-    links:
-      - app
+    depends_on:
+      app:
+        condition: service_healthy
     ports:
       - "8080:8080"
     command:
@@ -17,8 +24,15 @@ services:
         "-u",
         "http://app:8000/",
       ]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/__heartbeat__"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+
   test:
     build:
       context: ./integration_test
-    links:
-      - edge
+    depends_on:
+      edge:
+        condition: service_healthy

--- a/integration_test/sign_test_apk.sh
+++ b/integration_test/sign_test_apk.sh
@@ -5,10 +5,6 @@ set -ev
 host=$1
 port=$2
 
-while ! nc -z "$host" "$port"; do
-  echo -n "."
-  sleep 1 # wait for a sec before checking again
-done
 curl -F "input=@test.apk" -o /tmp/signed.apk \
   -H "Authorization: dd095f88adbf7bdfa18b06e23e83896107d7e0f969f7415830028fa2c1ccf9fd" \
   "http://$host:$port/sign"

--- a/integration_test/sign_test_xpi.sh
+++ b/integration_test/sign_test_xpi.sh
@@ -5,10 +5,6 @@ set -ev
 host=$1
 port=$2
 
-while ! nc -z "$host" "$port"; do
-  echo -n "."
-  sleep 1 # wait for a sec before checking again
-done
 curl -F "input=@test.xpi" -o /tmp/signed-default.xpi \
   -H "Authorization: c4180d2963fffdcd1cd5a1a343225288b964d8934b809a7d76941ccf67cc8547" \
   "http://$host:$port/sign"


### PR DESCRIPTION
This replaces both the `links` defined and the waiting we do in the test script.