### PR TITLE
add a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mozilla-services/autograph-devs @mozilla-services/autograph-mergers


### PR DESCRIPTION
This is the same as what we've [added in the main Autograph repo](https://github.com/mozilla-services/autograph/pull/922) except there's no need to look in addons folks.