### PR TITLE
fix: deploy to `latest` tag in circleci on pushes to `main`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
           name: Deploy to Dockerhub
           command: |
             # deploy master
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            if [ "${CIRCLE_BRANCH}" == "main" ]; then
               docker login -u $DOCKER_USER -p $DOCKER_PASS
               docker tag app:build ${DOCKERHUB_REPO}:latest
               docker push ${DOCKERHUB_REPO}:latest


### PR DESCRIPTION
Should've caught this in #321...but I didn't.