### PR TITLE
remove clang and libltdl-dev from build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,7 @@ RUN echo "deb-src http://deb.debian.org/debian/ bookworm-backports main" >> /etc
 RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get -y install --no-install-recommends \
-        clang \
         gcc \
-        libltdl-dev \
         golang-${GO_VERSION} \
         curl \
         ca-certificates && \

--- a/go.mod
+++ b/go.mod
@@ -43,4 +43,4 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 )
 
-go 1.22.5
+go 1.22.1


### PR DESCRIPTION
This should mildly speed up our build and reduce our image size.
