### PR TITLE
AUT-105: GitHub workflow for testing

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,48 @@
+name: Tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+# Restrict tests to the most recent commit.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Run unit tests
+        shell: bash
+        run: make test
+
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      
+      - name: Pull autograph image
+        shell: bash
+        run: docker pull mozilla/autograph
+
+      - name: Build autograph-edge
+        shell: bash
+        run: docker compose build
+
+      - name: Sign test APKs and XPIs and verify the APK
+        shell: bash
+        run: docker compose run test

--- a/main_test.go
+++ b/main_test.go
@@ -330,6 +330,9 @@ func Test_validateBaseURL(t *testing.T) {
 }
 
 func Test_preparedServer(t *testing.T) {
+	// For the purpose of testing - ensure we're using IPv4.
+	conf.BaseURL = "http://127.0.0.1:8000/"
+
 	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "Hello, client")
 	}))
@@ -421,7 +424,7 @@ func Test_preparedServer(t *testing.T) {
 				"X-Content-Type-Options":    []string{"nosniff"},
 				"Strict-Transport-Security": []string{"max-age=31536000;"},
 			},
-			expectedBody: `{"status":false,"checks":{"check_autograph_heartbeat":false},"details":"failed to request autograph heartbeat from http://localhost:8000/__heartbeat__: Get \"http://localhost:8000/__heartbeat__\": dial tcp 127.0.0.1:8000: connect: connection refused"}`,
+			expectedBody: `{"status":false,"checks":{"check_autograph_heartbeat":false},"details":"failed to request autograph heartbeat from http://127.0.0.1:8000/__heartbeat__: Get \"http://127.0.0.1:8000/__heartbeat__\": dial tcp 127.0.0.1:8000: connect: connection refused"}`,
 		},
 		{
 			name:           "test GET /sign path method not allowed",


### PR DESCRIPTION
This creates a github workflow to run the unit and integration tests for pull requests and on merge to the `main` branch.

Along the way we also encountered a flaky test that needed fixing. In particular connections to `http://localhost:8000` don't result in deterministic error messages because `localhost` can resolve to either `127.0.0.1` or `[::]`. To get a consistent result we needed to force the tests to use a fixed localhost address.