### PR TITLE
Fix malformed version.json generation

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -31,7 +31,7 @@ cat << EOF
 {
   "source": "${VERSION_SOURCE_URL}",
   "commit": "${VERSION_COMMIT_HASH}",
-  "version: "${VERSION_TAG_NAME}",
-  "build: "${VERSION_BUILD_URL}",
+  "version": "${VERSION_TAG_NAME}",
+  "build": "${VERSION_BUILD_URL}"
 }
 EOF


### PR DESCRIPTION
I must sheepishly admit that I YOLO'ed my last PR a little too quickly and never noticed that `version.sh` was generating invalid JSON. (And I am kinda surprised that there wasn't any test to catch it).

This should correct the generated version file so that it is parseable as valid JSON.