### PR TITLE
AUT-271: make separate tags and docker images pushes for production deploys of autograph-edge

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,8 +4,10 @@ on:
   push:
     branches:
       - main
-    tags:
-      - '[0-9]+.[0-9a-z]+.[0-9a-z]+'
+  release:
+    types:
+      - prereleased
+      - released
 
 jobs:
   docker:
@@ -26,12 +28,16 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
+          flavor:
+            # don't automatically tag with `latest`; we do this conditionally in the `tags` section
+            latest=false
           images: |
             ${{ vars.DOCKERHUB_REPO }}
             ${{ vars.GCP_PROJECT_ID && format('{0}-docker.pkg.dev/{1}/{2}/autograph-edge', vars.GAR_LOCATION, vars.GCP_PROJECT_ID, vars.GAR_REPOSITORY) }}
           tags: |
-            type=semver,pattern={{raw}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{raw}},enable=${{ github.event_name == 'release' && github.event.action == 'released' }}
+            type=semver,pattern={{raw}}-prerelease,enable=${{ github.event_name == 'release' && github.event.action == 'prereleased' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' }}
 
       - id: gcp-auth
         if: ${{ vars.GCP_PROJECT_ID }}


### PR DESCRIPTION
This change gives us separate tags for prereleases and releases, which will allow our deployment pipeline to separate out stage & production deploys.

I've also adjusted the `latest` tag to only be used on pushes to main, rather than all deployments. This will ensure that any ongoing dev work against main won't be disrupted if we cut a release.

Here's some example runs in my own repo (they fail, but the important part is the metadata step):
* [A push to main](https://github.com/bhearsum/autograph-edge/actions/runs/11298955041/job/31428961407), which just generates a `latest` tag
* [Publishing the `1.1.1` prerelease](https://github.com/bhearsum/autograph-edge/actions/runs/11298968687/job/31428998722) just generates a `1.1.1-prerelease` tag
* [Republishing `1.1.1` as a full release](https://github.com/bhearsum/autograph-edge/actions/runs/11298988470/job/31429054717) just generates a `1.1.1` tag