### PR TITLE
AUT-271: make separate tags and docker images pushes for production deploys of autograph-edge

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,8 +4,9 @@ on:
   push:
     branches:
       - main
-    tags:
-      - '[0-9]+.[0-9a-z]+.[0-9a-z]+'
+  release:
+    types:
+      - released
 
 jobs:
   docker:
@@ -26,18 +27,22 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
+          flavor:
+            # don't automatically tag with `latest`; we do this conditionally in the `tags` section
+            latest=false
           images: |
             ${{ vars.DOCKERHUB_REPO }}
             ${{ vars.GCP_PROJECT_ID && format('{0}-docker.pkg.dev/{1}/{2}/autograph-edge', vars.GAR_LOCATION, vars.GCP_PROJECT_ID, vars.GAR_REPOSITORY) }}
           tags: |
             type=semver,pattern={{raw}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' }}
+            type=sha,format=long,enable=${{ github.event_name == 'push' }}
 
       - id: gcp-auth
         if: ${{ vars.GCP_PROJECT_ID }}
         uses: google-github-actions/auth@v2
         with:
-          token_format: 'access_token'
+          token_format: "access_token"
           service_account: artifact-writer@${{ vars.GCP_PROJECT_ID}}.iam.gserviceaccount.com
           workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
 
@@ -61,10 +66,49 @@ jobs:
         run: ./version.sh | tee version.json
 
       - name: Build and push
+        # On pushes to `main`, we build and push a new image, so we can simply
+        # use the `docker/build-push-action` action.
+        if: ${{ github.event_name == 'push' }}
         uses: docker/build-push-action@v6
         with:
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'push' }}
           sbom: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           context: .
+
+      # copypasta from https://github.com/imjasonh/setup-crane/blob/main/action.yml
+      - name: Set up crane
+        shell: bash
+        run: |
+          set -ex
+
+          out=crane
+          os=${{ runner.os }}
+          tag=$(curl -s -u "username:${{ github.token }}" https://api.github.com/repos/google/go-containerregistry/releases/latest | jq -r '.tag_name')
+          arch=$(uname -m)
+          tmp=$(mktemp -d)
+          cd ${tmp}
+          curl -fsL https://github.com/google/go-containerregistry/releases/download/${tag}/go-containerregistry_${os}_${arch}.tar.gz | tar xz ${out}
+          chmod +x ${tmp}/${out}
+          PATH=${PATH}:${tmp}
+          echo "${tmp}" >> $GITHUB_PATH
+          echo "${{ github.token }}" | crane auth login ghcr.io --username "dummy" --password-stdin
+
+      - name: Tag and push
+        # For releases, we specifically do _not_ want to rebuild, just tag the
+        # existing image and push. There's no officially maintained action for
+        # this use case, but it's trivial enough to do ourselves.
+        if: ${{ github.event_name == 'release' }}
+        env:
+          # Tags come in the form of a fully qualified image name and tag, eg:
+          # mozilla/autograph:1.1.8
+          # us-west2-docker.pkg.dev/autograph-proj/autograph-repo/autograph:1.1.8
+          TAGS: ${{ steps.meta.outputs.tags }}
+          SRC: ${{ vars.DOCKERHUB_REPO}}:sha-${{ github.sha }}
+        run: |
+          crane digest $SRC
+          crane manifest $SRC
+          for tag in $TAGS; do
+            crane copy $SRC $tag
+          done


### PR DESCRIPTION
This change gives us separate tags for prereleases and releases, which will allow our deployment pipeline to separate out stage & production deploys.

I've also adjusted the `latest` tag to only be used on pushes to main, rather than all deployments. This will ensure that any ongoing dev work against main won't be disrupted if we cut a release.

Here's some example runs in my own repo (they fail, but the important part is the metadata step):
* [A push to main](https://github.com/bhearsum/autograph-edge/actions/runs/11298955041/job/31428961407), which just generates a `latest` tag
* [Publishing the `1.1.1` prerelease](https://github.com/bhearsum/autograph-edge/actions/runs/11298968687/job/31428998722) just generates a `1.1.1-prerelease` tag
* [Republishing `1.1.1` as a full release](https://github.com/bhearsum/autograph-edge/actions/runs/11298988470/job/31429054717) just generates a `1.1.1` tag