### PR TITLE
correct deploy workflows by renaming generate target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@ GO := GO111MODULE=on go
 
 all: lint vet test install
 
-version.json:
+generate:
 	$(GO) generate
 
-install: version.json
+install: generate
 	$(GO) install .
-test: version.json
+test: generate
 	MOCK_AUTOGRAPH_CALLS=1 $(GO) test -v -count=1 -covermode=count -coverprofile=coverage.out .
 showcoverage: test
 	$(GO) tool cover -html=coverage.out


### PR DESCRIPTION
In https://github.com/mozilla-services/autograph-edge/pull/337, we
reference `make generate` like in the autograph repo.

But here that was called `make version.json`. For consistency, and any
possible (though, unlikely) additions to what needs to be generate, we
rename the make target to `generate` and leave the deploy workflow
alone.
